### PR TITLE
(#31) detect stale active states

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -18,7 +18,7 @@ type ClientOpts struct {
 	replicas      int
 	queue         *Queue
 	taskRetention time.Duration
-	retryPolicy   RetryPolicy
+	retryPolicy   RetryPolicyProvider
 	memoryStore   bool
 	statsPort     int
 	logger        Logger
@@ -110,7 +110,7 @@ func MemoryStorage() ClientOpt {
 }
 
 // RetryBackoffPolicy uses p to schedule job retries, defaults to a linear curve backoff with jitter between 1 and 10 minutes
-func RetryBackoffPolicy(p RetryPolicy) ClientOpt {
+func RetryBackoffPolicy(p RetryPolicyProvider) ClientOpt {
 	return func(opts *ClientOpts) error {
 		opts.retryPolicy = p
 		return nil

--- a/storage_test.go
+++ b/storage_test.go
@@ -559,24 +559,6 @@ var _ = Describe("Storage", func() {
 			})
 		})
 
-		It("Should handle unknown queues", func() {
-			withJetStream(func(nc *nats.Conn, mgr *jsm.Manager) {
-				storage, err := newJetStreamStorage(nc, retryForTesting, &defaultLogger{})
-				Expect(err).ToNot(HaveOccurred())
-
-				q := testQueue()
-				Expect(storage.PrepareQueue(q, 1, true)).ToNot(HaveOccurred())
-				Expect(storage.PrepareTasks(true, 1, time.Hour)).ToNot(HaveOccurred())
-
-				task, err := NewTask("ginkgo", nil)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(storage.EnqueueTask(context.Background(), q, task)).ToNot(HaveOccurred())
-
-				delete(storage.qStreams, q.Name)
-				Expect(storage.RetryTaskByID(context.Background(), q, task.ID)).To(MatchError("unknown queue ginkgo"))
-			})
-		})
-
 		It("Should remove the task from the queue and enqueue with retry state", func() {
 			withJetStream(func(nc *nats.Conn, mgr *jsm.Manager) {
 				storage, err := newJetStreamStorage(nc, retryForTesting, &defaultLogger{})


### PR DESCRIPTION
Also set the queues to max messages per subject of 1
to simplify retries - no need to delete any old item
it will be automatic. This also sets a automatic dedup
however when enqueuing we still correctl detect
dupes and errors accordingly.

Signed-off-by: R.I.Pienaar <rip@devco.net>