### PR TITLE
(#15) support basic lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ This package heavily inspired by [hibiken/asynq](https://github.com/hibiken/asyn
 
 ## Status
 
-This is a brand-new project, under heavy development and relies on unreleased behaviors in JetStream. Interfaces might change,
+This is a brand-new project, under heavy development. Interfaces might change,
 Structures might change, features might be removed if it's found to be a bad fit for the underlying storage.
 
 Use with care.
+
+## Requirements
+
+NATS 2.7.2 with JetStream enabled.
 
 ## Features
 

--- a/client_test.go
+++ b/client_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Client", func() {
 		})
 	})
 
-	Describe("discardTaskIfDesired", func() {
+	Describe("saveOrDiscardTaskIfDesired", func() {
 		It("Should delete the correct tasks", func() {
 			withJetStream(func(nc *nats.Conn, mgr *jsm.Manager) {
 				client, err := NewClient(NatsConn(nc), DiscardTaskStates(TaskStateExpired, TaskStateCompleted))
@@ -97,12 +97,12 @@ var _ = Describe("Client", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(client.EnqueueTask(context.Background(), task)).ToNot(HaveOccurred())
 
-				Expect(client.discardTaskIfDesired(task)).ToNot(HaveOccurred())
+				Expect(client.saveOrDiscardTaskIfDesired(context.Background(), task)).ToNot(HaveOccurred())
 				_, err = client.LoadTaskByID(task.ID)
 				Expect(err).ToNot(HaveOccurred())
 
 				task.State = TaskStateExpired
-				Expect(client.discardTaskIfDesired(task)).ToNot(HaveOccurred())
+				Expect(client.saveOrDiscardTaskIfDesired(context.Background(), task)).ToNot(HaveOccurred())
 				_, err = client.LoadTaskByID(task.ID)
 				Expect(err).To(MatchError("task not found"))
 			})

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/nats-io/jsm.go v0.0.28-0.20220128163911-90cd1007b323
-	github.com/nats-io/nats-server/v2 v2.7.2-0.20220201222209-2ed7a812d8b2
+	github.com/nats-io/nats-server/v2 v2.7.2
 	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/onsi/ginkgo/v2 v2.1.1
 	github.com/onsi/gomega v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/nats-io/jsm.go v0.0.28-0.20220128163911-90cd1007b323/go.mod h1:HU1JmK
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 h1:vU9tpM3apjYlLLeY23zRWJ9Zktr5jp+mloR942LEOpY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.7.2-0.20220126224453-26b692ee73c0/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
-github.com/nats-io/nats-server/v2 v2.7.2-0.20220201222209-2ed7a812d8b2 h1:/ocgZt+pxx9ocGWWdeBAJfg0tqoz4uUoIgCNepKnnDQ=
-github.com/nats-io/nats-server/v2 v2.7.2-0.20220201222209-2ed7a812d8b2/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
+github.com/nats-io/nats-server/v2 v2.7.2 h1:+LEN8m0+jdCkiGc884WnDuxR+qj80/5arj+szKuRpRI=
+github.com/nats-io/nats-server/v2 v2.7.2/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d h1:GRSmEJutHkdoxKsRypP575IIdoXe7Bm6yHQF6GcDBnA=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2022, R.I. Pienaar and the Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package asyncjobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/segmentio/ksuid"
+)
+
+type BaseEvent struct {
+	EventID   string `json:"event_id"`
+	EventType string `json:"type"`
+	TimeStamp int64  `json:"timestamp"`
+}
+
+type TaskStateChangeEvent struct {
+	TaskID   string        `json:"task_id"`
+	State    TaskState     `json:"state"`
+	Tries    int           `json:"tries"`
+	Queue    string        `json:"queue"`
+	TaskType string        `json:"task_type"`
+	LastErr  string        `json:"last_error,omitempty"`
+	Age      time.Duration `json:"task_age,omitempty"`
+
+	BaseEvent
+}
+
+const (
+	// TaskStateChangeEventType is the event type for TaskStateChangeEvent types
+	TaskStateChangeEventType = "io.choria.asyncjobs.v1.task_state"
+)
+
+func ParseEventJSON(event []byte) (interface{}, string, error) {
+	var base BaseEvent
+	err := json.Unmarshal(event, &base)
+	if err != nil {
+		return nil, "", err
+	}
+
+	switch base.EventType {
+	case TaskStateChangeEventType:
+		var e TaskStateChangeEvent
+		err := json.Unmarshal(event, &e)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return e, base.EventType, nil
+	default:
+		return nil, base.EventType, fmt.Errorf("unknown event type %s", base.EventType)
+	}
+}
+
+// NewTaskStateChangeEvent creates a new event notifying of a change in task state
+func NewTaskStateChangeEvent(t *Task) (*TaskStateChangeEvent, error) {
+	eid, err := ksuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+
+	e := &TaskStateChangeEvent{
+		TaskID:   t.ID,
+		State:    t.State,
+		Tries:    t.Tries,
+		Queue:    t.Queue,
+		TaskType: t.Type,
+		LastErr:  t.LastErr,
+		BaseEvent: BaseEvent{
+			EventID:   eid.String(),
+			TimeStamp: eid.Time().UnixNano(),
+			EventType: TaskStateChangeEventType,
+		},
+	}
+
+	if !t.CreatedAt.IsZero() {
+		e.Age = time.Since(t.CreatedAt)
+	}
+
+	return e, nil
+}

--- a/processor_test.go
+++ b/processor_test.go
@@ -246,13 +246,13 @@ var _ = Describe("Processor", func() {
 
 				<-proc.limiter
 				task.State = TaskStateCompleted
-				Expect(client.storage.SaveTaskState(ctx, task)).ToNot(HaveOccurred())
+				Expect(client.storage.SaveTaskState(ctx, task, false)).ToNot(HaveOccurred())
 				err = proc.processMessage(ctx, &ProcessItem{JobID: task.ID})
 				Expect(err).To(MatchError("already in state \"complete\""))
 
 				<-proc.limiter
 				task.State = TaskStateExpired
-				Expect(client.storage.SaveTaskState(ctx, task)).ToNot(HaveOccurred())
+				Expect(client.storage.SaveTaskState(ctx, task, false)).ToNot(HaveOccurred())
 				err = proc.processMessage(ctx, &ProcessItem{JobID: task.ID})
 				Expect(err).To(MatchError("already in state \"expired\""))
 

--- a/task.go
+++ b/task.go
@@ -110,6 +110,11 @@ func NewTask(taskType string, payload interface{}, opts ...TaskOpt) (*Task, erro
 	return t, nil
 }
 
+// IsPastDeadline determines if the task is past it's deadline
+func (t *Task) IsPastDeadline() bool {
+	return t.Deadline != nil && time.Since(*t.Deadline) > 0
+}
+
 // TaskOpt configures Tasks made using NewTask()
 type TaskOpt func(*Task) error
 


### PR DESCRIPTION
Events emitted for task changes initially.

ajc task watch updated to use these events

Signed-off-by: R.I.Pienaar <rip@devco.net>