### PR TITLE
(#40) improve connection robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,7 @@ Use with care.
 Tasks are published to Work Queues:
 
 ```go
-// connect to NATS
-nc,  := nats.Connect("localhost:4222")
-
-// establish a connection to the EMAIL work queue
+// establish a connection to the EMAIL work queue using a NATS context
 client, _ := asyncjobs.NewClient(asyncjobs.NatsConn(nc), asyncjobs.BindWorkQueue("EMAIL"))
 
 // create a task with the type 'email:new' and body from newEmail()
@@ -57,7 +54,8 @@ Tasks are processes by horizontally and vertically scalable. Typically, a Handle
 integration, concurrency and backoffs configured.
 
 ```go
-// establish a connection to the EMAIL work queue using a NATS context, with concurrency, prometheus stats and backoff
+// establish a connection to the EMAIL work queue using a 
+// NATS context, with concurrency, prometheus stats and backoff
 client, _ := asyncjobs.NewClient(
 	asyncjobs.NatsContext("EMAIL"), 
 	asyncjobs.BindWorkQueue("EMAIL"),

--- a/ajc/util.go
+++ b/ajc/util.go
@@ -29,6 +29,10 @@ func prepare(copts ...asyncjobs.ClientOpt) error {
 	} else {
 		logger.SetLevel(logrus.InfoLevel)
 	}
+	logger.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "15:04:05",
+	})
 	log = logrus.NewEntry(logger)
 
 	if nctx == "" {
@@ -38,22 +42,8 @@ func prepare(copts ...asyncjobs.ClientOpt) error {
 	var err error
 
 	conn := []nats.Option{
-		nats.MaxReconnects(10),
 		nats.Name("Choria Asynchronous Jobs CLI version " + version),
-		nats.ReconnectHandler(func(nc *nats.Conn) {
-			log.Printf("Reconnected to NATS server %s", nc.ConnectedUrl())
-		}),
-		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
-			log.Printf("Disconnected from server: %v", err)
-		}),
-		nats.ErrorHandler(func(nc *nats.Conn, _ *nats.Subscription, err error) {
-			url := nc.ConnectedUrl()
-			if url == "" {
-				log.Printf("Unexpected NATS error: %s", err)
-			} else {
-				log.Printf("Unexpected NATS error from server %s: %s", url, err)
-			}
-		}),
+		nats.PingInterval(30 * time.Second),
 	}
 
 	opts := []asyncjobs.ClientOpt{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/nats-io/jsm.go v0.0.28-0.20220128163911-90cd1007b323
-	github.com/nats-io/nats-server/v2 v2.7.2
+	github.com/nats-io/nats-server/v2 v2.7.3-0.20220207172817-d71bb63e1bcf
 	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/onsi/ginkgo/v2 v2.1.1
 	github.com/onsi/gomega v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/nats-io/jsm.go v0.0.28-0.20220128163911-90cd1007b323/go.mod h1:HU1JmK
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 h1:vU9tpM3apjYlLLeY23zRWJ9Zktr5jp+mloR942LEOpY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.7.2-0.20220126224453-26b692ee73c0/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
-github.com/nats-io/nats-server/v2 v2.7.2 h1:+LEN8m0+jdCkiGc884WnDuxR+qj80/5arj+szKuRpRI=
-github.com/nats-io/nats-server/v2 v2.7.2/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
+github.com/nats-io/nats-server/v2 v2.7.3-0.20220207172817-d71bb63e1bcf h1:55DKmyEQtdS8hRMbUyGN7IX1PNX9zG/THqshbULr6NY=
+github.com/nats-io/nats-server/v2 v2.7.3-0.20220207172817-d71bb63e1bcf/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d h1:GRSmEJutHkdoxKsRypP575IIdoXe7Bm6yHQF6GcDBnA=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=


### PR DESCRIPTION
When a context is supplied a more appropriate
set of options is now supplied, with reconnects,
logging and more.

Also allow backoff policy to be picked on the cli
and minor log format changes

Signed-off-by: R.I.Pienaar <rip@devco.net>