### PR TITLE
(#51) additional packager settings

### DIFF
--- a/ajc/package_command.go
+++ b/ajc/package_command.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/choria-io/asyncjobs/generators"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -58,6 +59,9 @@ func (c *packageCommand) dockerAction(_ *kingpin.ParseContext) error {
 	if h.Name == "" {
 		h.Name = "choria.io/asyncjobs/handlers"
 	}
+	if h.RetryPolicy == "" {
+		h.RetryPolicy = "default"
+	}
 
 	if len(h.TaskHandlers) == 0 {
 		return fmt.Errorf("no task handlers specified in %s", c.file)
@@ -68,6 +72,12 @@ func (c *packageCommand) dockerAction(_ *kingpin.ParseContext) error {
 	table.AddRow("NATS Context Name", h.ContextName)
 	table.AddRow("Work Queue", h.WorkQueue)
 	table.AddRow("Task Handlers", len(h.TaskHandlers))
+	table.AddRow("Retry Backoff Policy", h.RetryPolicy)
+	if len(h.DiscardStates) > 0 {
+		table.AddRow("End State Discard", strings.Join(h.DiscardStates, ", "))
+	} else {
+		table.AddRow("End State Discard", "none")
+	}
 	table.AddRow("github.com/choria-io/asyncjobs", h.AJVersion)
 	fmt.Println(table.Render())
 

--- a/client_options.go
+++ b/client_options.go
@@ -138,6 +138,18 @@ func RetryBackoffPolicy(p RetryPolicyProvider) ClientOpt {
 	}
 }
 
+// RetryBackoffPolicyName uses the policy named to schedule job retries by using RetryPolicyLookup(name)
+func RetryBackoffPolicyName(name string) ClientOpt {
+	return func(opts *ClientOpts) error {
+		p, err := RetryPolicyLookup(name)
+		if err != nil {
+			return err
+		}
+
+		return RetryBackoffPolicy(p)(opts)
+	}
+}
+
 // ClientConcurrency sets the concurrency to use when executing tasks within this client for horizontal scaling.
 // This is capped by the per-queue maximum concurrency set using the queue setting MaxConcurrent. Generally a
 // queue would have a larger concurrency like 100 (DefaultQueueMaxConcurrent) and an individual task processor
@@ -195,7 +207,7 @@ func BindWorkQueue(queue string) ClientOpt {
 	}
 }
 
-// TaskRetention is the time tasks will be kept with.
+// TaskRetention is the time tasks will be kept for in the task storage
 //
 // Used only when initially creating the underlying streams.
 func TaskRetention(r time.Duration) ClientOpt {

--- a/errors.go
+++ b/errors.go
@@ -63,6 +63,9 @@ var (
 	// ErrUnknownEventType indicates that while parsing an event an unknown type of event was encountered
 	ErrUnknownEventType = fmt.Errorf("unknown event type")
 
+	// ErrUnknownRetryPolicy indicates the requested retry policy does not exist
+	ErrUnknownRetryPolicy = fmt.Errorf("unknown retry policy")
+
 	// ErrRequestReplyFailed indicates a callout to a remote handler failed due to a timeout, lack of listerners or network error
 	ErrRequestReplyFailed = fmt.Errorf("request-reply callout failed")
 	// ErrRequestReplyNoDeadline indicates a request-reply handler was called without a deadline

--- a/generators/fs/godocker/Dockerfile.templ
+++ b/generators/fs/godocker/Dockerfile.templ
@@ -4,7 +4,9 @@ WORKDIR /usr/src/app
 
 RUN go mod init "{{ .Package.Name }}" && \
 {{- range $handler := .Package.TaskHandlers }}
+  {{- if not $handler.RequestReply }}
     go get "{{ $handler.Package }}@{{ $handler.Version }}" && \
+  {{- end }}
 {{- end }}
     go get github.com/choria-io/asyncjobs@{{ .Package.AJVersion }}
 

--- a/generators/fs/godocker/main.go.templ
+++ b/generators/fs/godocker/main.go.templ
@@ -26,9 +26,9 @@ var usage = `This is a generated Handler service for the Choria Async Jobs Proje
 It hosts the following handlers:
 {{ range $handler := .Package.TaskHandlers }}
   {{- if $handler.RequestReply }}
- - {{ $handler.TaskType }}: {{ $handler.Package }}@{{ $handler.Version }}
-  {{- else }}
  - {{ $handler.TaskType}}: Remote Request-Reply Service
+  {{- else }}
+ - {{ $handler.TaskType }}: {{ $handler.Package }}@{{ $handler.Version }}
   {{- end }}
 {{- end }}
 
@@ -37,6 +37,7 @@ The following Environment variables are supported:
  - AJ_WORK_QUEUE: The Work Queue to consume from, defaults to DEFAULT
  - AJ_NATS_CONTEXT: The name of a NATS Context to use for connections
  - AJ_CONCURRENCY: The number of concurrent handlers that can be run
+ - AJ_RETRY_POLICY: The retry policy to use [{{ RetryNamesList }}]
 
 Prometheus statistics are Exposed on port http://0.0.0.0:8080/metrics
 
@@ -95,15 +96,33 @@ func main() {
 		TimestampFormat: "15:04:05",
 	})
 
+	retryPolicy := os.Getenv("AJ_RETRY_POLICY")
+	if retryPolicy == "" {
+		retryPolicy = "{{ .Package.RetryPolicy }}"
+	}
+
 	log := logrus.NewEntry(logger)
 
-	log.Printf("Connecting using Context %s consuming work queue %s with concurrency %d", nctx, wq, concurrency)
+	log.Printf("Choria Async Jobs Handler Service {{.Package.Name}} build settings")
+	log.Printf("NATS Context: %s", nctx)
+	log.Printf("Work Queue: %s", wq)
+	log.Printf("Concurrency: %d", concurrency)
+	log.Printf("Retry Policy: %s", retryPolicy)
+{{- range $state := .Package.DiscardStates }}
+	log.Printf("Discard State: {{$state}}")
+{{- end }}
+	log.Printf("Prometheus Port: 8080")
+	log = log.WithField("queue", wq)
 
 	client, err := aj.NewClient(
 		aj.NatsContext(nctx),
 		aj.BindWorkQueue(wq),
 		aj.ClientConcurrency(concurrency),
 		aj.CustomLogger(log),
+		aj.RetryBackoffPolicyName(retryPolicy),
+{{- range $state := .Package.DiscardStates }}
+		aj.DiscardTaskStates("{{$state}}"),
+{{- end }}
 		aj.PrometheusListenPort(8080))
 	usageIfError(err)
 

--- a/generators/godocker.go
+++ b/generators/godocker.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	aj "github.com/choria-io/asyncjobs"
 )
 
 // GoContainer builds docker containers based on the package spec
@@ -43,6 +45,10 @@ func (g *GoContainer) RenderToDirectory(target string) error {
 		return err
 	}
 
+	if g.Package.RetryPolicy == "" {
+		g.Package.RetryPolicy = "default"
+	}
+
 	for _, p := range g.Package.TaskHandlers {
 		if p.RequestReply {
 			continue
@@ -59,6 +65,9 @@ func (g *GoContainer) RenderToDirectory(target string) error {
 	}
 
 	funcs := map[string]interface{}{
+		"RetryNamesList": func() string {
+			return strings.Join(aj.RetryPolicyNames(), ", ")
+		},
 		"TypeToPackageName": func(t string) string {
 			remove := []string{"_", "-", ":", "/", "\\"}
 			res := t

--- a/generators/package.go
+++ b/generators/package.go
@@ -22,6 +22,10 @@ type Package struct {
 	Name string `yaml:"name"`
 	// AJVersion is an optional version to use for the choria-io/asyncjobs dependency
 	AJVersion string `yaml:"asyncjobs"`
+	// RetryPolicy is the name of a retry policy, see RetryPolicyNames()
+	RetryPolicy string `yaml:"retry"`
+	// DiscardStates indicates what termination states to discard
+	DiscardStates []string `yaml:"discard"`
 }
 
 // TaskHandler is an individual Task Handler

--- a/processor_test.go
+++ b/processor_test.go
@@ -321,6 +321,7 @@ var _ = Describe("Processor", func() {
 
 				router := NewTaskRouter()
 				router.HandleFunc("ginkgo", func(ctx context.Context, log Logger, task *Task) (interface{}, error) {
+					// these will panic as its in a different routine, but they are supposed to pass so thats fine
 					t, err := client.LoadTaskByID(task.ID)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(t.State).To(Equal(TaskStateActive))

--- a/retrypolicy_test.go
+++ b/retrypolicy_test.go
@@ -6,12 +6,39 @@ import (
 )
 
 var _ = Describe("RetryPolicy", func() {
-	It("Should determine the correct interval with jitter", func() {
-		b := RetryLinearOneMinute.Duration(10)
-		d := RetryLinearOneMinute.Intervals[10]
+	Describe("Duration", func() {
+		It("Should determine the correct interval with jitter", func() {
+			b := RetryLinearOneMinute.Duration(10)
+			d := RetryLinearOneMinute.Intervals[10]
 
-		Expect(b).ToNot(Equal(d))
-		Expect(b).To(BeNumerically(">", float64(d)*0.5))
-		Expect(b).To(BeNumerically("<", float64(d)+float64(d)*0.5))
+			Expect(b).ToNot(Equal(d))
+			Expect(b).To(BeNumerically(">", float64(d)*0.5))
+			Expect(b).To(BeNumerically("<", float64(d)+float64(d)*0.5))
+		})
+	})
+
+	Describe("RetryPolicyNames", func() {
+		It("Should have the right names", func() {
+			Expect(RetryPolicyNames()).To(Equal([]string{"10m", "1h", "1m", "default"}))
+		})
+	})
+
+	Describe("RetryPolicyLookup", func() {
+		It("Should find the right policy", func() {
+			_, err := RetryPolicyLookup("missing")
+			Expect(err).To(MatchError(ErrUnknownRetryPolicy))
+
+			p, err := RetryPolicyLookup("1m")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(p).To(Equal(RetryLinearOneMinute))
+		})
+	})
+
+	Describe("IsRetryPolicyKnown", func() {
+		It("Should report correct values", func() {
+			Expect(IsRetryPolicyKnown("foo")).To(BeFalse())
+			Expect(IsRetryPolicyKnown("default")).To(BeTrue())
+			Expect(IsRetryPolicyKnown("1m")).To(BeTrue())
+		})
 	})
 })


### PR DESCRIPTION
This supports Retry Policy and End State Discard
settings for packages

Did some refactors and updates to make supporting
that easier and so also made the cli generation a
bit more dynamic.

Logging in generated main.go is more detailed

Signed-off-by: R.I.Pienaar <rip@devco.net>