### PR TITLE
(#80) support dependencies in tasks

### DIFF
--- a/ajc/queue_command.go
+++ b/ajc/queue_command.go
@@ -37,7 +37,7 @@ func configureQueueCommand(app *kingpin.Application) {
 	add.Arg("queue", "Queue to Configure").Required().StringVar(&c.name)
 	add.Flag("age", "Sets the maximum age for entries to keep, 0s for unlimited").Default("0s").DurationVar(&c.maxAge)
 	add.Flag("entries", "Sets the maximum amount of entries to keep, 0 for unlimited").Default("0").IntVar(&c.maxEntries)
-	add.Flag("tries", "Maximum delivery attempts to allow per message, -1 for unlimited").Default(fmt.Sprintf("%d", asyncjobs.DefaultMaxTries)).IntVar(&c.maxTries)
+	add.Flag("tries", "Maximum delivery attempts to allow per message, -1 for unlimited").Default("-1").IntVar(&c.maxTries)
 	add.Flag("run-time", "Maximum run-time to allow per task").Default(asyncjobs.DefaultJobRunTime.String()).DurationVar(&c.maxTime)
 	add.Flag("concurrent", "Maximum concurrent jobs that can be ran").Default(fmt.Sprintf("%d", asyncjobs.DefaultQueueMaxConcurrent)).IntVar(&c.maxConcurrent)
 	add.Flag("memory", "Store the Queue in memory").BoolVar(&c.memory)
@@ -68,7 +68,7 @@ func configureQueueCommand(app *kingpin.Application) {
 }
 
 func (c *queueCommand) addAction(_ *kingpin.ParseContext) error {
-	err := prepare()
+	err := prepare(asyncjobs.NoStorageInit())
 	if err != nil {
 		return err
 	}

--- a/asyncjobs.go
+++ b/asyncjobs.go
@@ -18,7 +18,7 @@ const (
 	ShortedScheduledDeadline = 30 * time.Second
 	// DefaultJobRunTime when not configured for a queue this is the default run-time handlers will get
 	DefaultJobRunTime = time.Hour
-	// DefaultMaxTries when not configured for a queue this is the default tries it will get
+	// DefaultMaxTries when not configured for a task this is the default tries it will get
 	DefaultMaxTries = 10
 	// DefaultQueueMaxConcurrent when not configured for a queue this is the default concurrency setting
 	DefaultQueueMaxConcurrent = 100
@@ -63,6 +63,7 @@ type Storage interface {
 	DeleteTaskByID(id string) error
 	PublishTaskStateChangeEvent(ctx context.Context, task *Task) error
 	AckItem(ctx context.Context, item *ProcessItem) error
+	NakBlockedItem(ctx context.Context, item *ProcessItem) error
 	NakItem(ctx context.Context, item *ProcessItem) error
 	TerminateItem(ctx context.Context, item *ProcessItem) error
 	PollQueue(ctx context.Context, q *Queue) (*ProcessItem, error)

--- a/errors.go
+++ b/errors.go
@@ -34,6 +34,8 @@ var (
 	ErrTaskTypeRequired = fmt.Errorf("task type is required")
 	// ErrTaskTypeInvalid indicates an invalid task type was given
 	ErrTaskTypeInvalid = fmt.Errorf("task type is invalid")
+	// ErrTaskDependenciesFailed indicates that the task cannot be run as its dependencies failed
+	ErrTaskDependenciesFailed = fmt.Errorf("task dependencies failed")
 
 	// ErrNoHandlerForTaskType indicates that a task could not be handled by any known handlers
 	ErrNoHandlerForTaskType = fmt.Errorf("no handler for task type")

--- a/retrypolicy.go
+++ b/retrypolicy.go
@@ -28,8 +28,8 @@ type RetryPolicyProvider interface {
 }
 
 var (
-	// RetryLinearTenMinutes is a 20-step policy between 1 and 10 minutes
-	RetryLinearTenMinutes = linearPolicy(20, 0.90, time.Minute, 10*time.Minute)
+	// RetryLinearTenMinutes is a 50-step policy between 1 and 10 minutes
+	RetryLinearTenMinutes = linearPolicy(50, 0.90, time.Minute, 10*time.Minute)
 
 	// RetryLinearOneHour is a 50-step policy between 10 minutes and 1 hour
 	RetryLinearOneHour = linearPolicy(20, 0.90, 10*time.Minute, 60*time.Minute)

--- a/stats.go
+++ b/stats.go
@@ -61,6 +61,11 @@ var (
 		Help: "The number of task updates that failed",
 	}, []string{})
 
+	taskDependenciesFailedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(prometheusNamespace, "task", "dependencies_failed"),
+		Help: "The number of tasks that failed because their dependencies had errors",
+	}, []string{})
+
 	handlersBusyGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: prometheus.BuildFQName(prometheusNamespace, "handler", "busy_count"),
 		Help: "The number busy handlers",
@@ -110,6 +115,7 @@ func init() {
 
 	prometheus.MustRegister(taskUpdateCounter)
 	prometheus.MustRegister(taskUpdateErrorCounter)
+	prometheus.MustRegister(taskDependenciesFailedCounter)
 
 	prometheus.MustRegister(handlersBusyGauge)
 	prometheus.MustRegister(handlersErroredCounter)

--- a/storage_test.go
+++ b/storage_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Storage", func() {
 				err := storage.PrepareQueue(q, 1, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(q.MaxTries).To(Equal(DefaultMaxTries))
+				Expect(q.MaxTries).To(Equal(-1))
 				Expect(q.MaxRunTime).To(Equal(DefaultJobRunTime))
 				Expect(q.MaxConcurrent).To(Equal(DefaultQueueMaxConcurrent))
 			})

--- a/task_test.go
+++ b/task_test.go
@@ -10,16 +10,30 @@ import (
 var _ = Describe("Tasks", func() {
 	Describe("NewTask", func() {
 		It("Should create a valid task with options supplied", func() {
+			p, err := NewTask("parent", nil)
+			Expect(err).ToNot(HaveOccurred())
+
 			deadline := time.Now().Add(time.Hour)
 			payload := map[string]string{"hello": "world"}
-			task, err := NewTask("test", payload, TaskDeadline(deadline))
+			task, err := NewTask("test", payload, TaskDeadline(deadline), TaskDependsOnIDs("1", "2", "2", "1", "2"), TaskDependsOn(p, p), TaskRequiresDependencyResults())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(task.Deadline).To(Equal(&deadline))
 			Expect(task.ID).ToNot(HaveLen(0))
 			Expect(task.Type).To(Equal("test"))
 			Expect(task.Payload).To(MatchJSON(`{"hello":"world"}`))
 			Expect(task.CreatedAt).To(BeTemporally("~", time.Now(), 50*time.Millisecond))
+			Expect(task.Dependencies).To(HaveLen(3))
+			Expect(task.Dependencies).To(Equal([]string{"1", "2", p.ID}))
+			Expect(task.State).To(Equal(TaskStateBlocked)) // because we have dependencies
+			Expect(task.LoadDependencies).To(BeTrue())
+			Expect(task.MaxTries).To(Equal(DefaultMaxTries))
+
+			// without dependencies, should be new
+			task, err = NewTask("test", payload, TaskDeadline(deadline), TaskMaxTries(10))
+			Expect(err).ToNot(HaveOccurred())
 			Expect(task.State).To(Equal(TaskStateNew))
+			Expect(task.LoadDependencies).To(BeFalse())
+			Expect(task.MaxTries).To(Equal(10))
 		})
 	})
 })


### PR DESCRIPTION
This introduce the notion of dependencies between jobs
a job with dependencies starts off as Blocked and will
periodically check on it's dependencies, if its dependencies
fails it becomes Unreachable

This adjusts the default queue retries up to unlimited
instead defaulting task tries to 10, end result more or
less the same but the change it needed because checking
a blocked task dependencies is a delivery attempt on
the queue, so it would prematurely terminate blocked tasks

This is in aid of supporting a tool that can create a large
set of tasks, perhaps from a DAG, and have the processors
handle the exection.

At present it can take some time to process a large DAG of
tasks since each one will individiaully - every 5 seconds -
decide if its Unreachable or not and it only checks its
immediate parents, so an early failure on a long chain of
tasks can take some time to bubble through, will think about
optimising that. The lack of transactions for KV is a pain.

Signed-off-by: R.I.Pienaar <rip@devco.net>