### PR TITLE
feat: add empty logger for prod use

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 		replicas:    1,
 		concurrency: 10,
 		retryPolicy: RetryDefault,
-		logger:      &defaultLogger{},
+		logger:      &emptyLogger{},
 	}
 
 	var err error

--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 		replicas:    1,
 		concurrency: 10,
 		retryPolicy: RetryDefault,
-		logger:      &emptyLogger{},
+		logger:      &noopLogger{},
 	}
 
 	var err error

--- a/logger.go
+++ b/logger.go
@@ -16,6 +16,7 @@ type Logger interface {
 	Errorf(format string, v ...interface{})
 }
 
+// Default console logger
 type defaultLogger struct{}
 
 func (l *defaultLogger) Infof(format string, v ...interface{}) {
@@ -34,9 +35,10 @@ func (l *defaultLogger) Debugf(format string, v ...interface{}) {
 	log.Printf(format, v...)
 }
 
-type emptyLogger struct{}
+// Logger placeholder
+type noopLogger struct{}
 
-func (l *emptyLogger) Infof(format string, v ...interface{})  {}
-func (l *emptyLogger) Warnf(format string, v ...interface{})  {}
-func (l *emptyLogger) Errorf(format string, v ...interface{}) {}
-func (l *emptyLogger) Debugf(format string, v ...interface{}) {}
+func (l *noopLogger) Infof(format string, v ...interface{})  {}
+func (l *noopLogger) Warnf(format string, v ...interface{})  {}
+func (l *noopLogger) Errorf(format string, v ...interface{}) {}
+func (l *noopLogger) Debugf(format string, v ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -33,3 +33,10 @@ func (l *defaultLogger) Errorf(format string, v ...interface{}) {
 func (l *defaultLogger) Debugf(format string, v ...interface{}) {
 	log.Printf(format, v...)
 }
+
+type emptyLogger struct{}
+
+func (l *emptyLogger) Infof(format string, v ...interface{})  {}
+func (l *emptyLogger) Warnf(format string, v ...interface{})  {}
+func (l *emptyLogger) Errorf(format string, v ...interface{}) {}
+func (l *emptyLogger) Debugf(format string, v ...interface{}) {}


### PR DESCRIPTION
This PR adds a default empty logger fot client. It's annoying to have choria messages in the application code.
Altho it is possible to pass a custom logger, it's inconvenient. 

If I wanna have a `DEBUG` level for my client code, but wanna have a silent AJC, I need to instantiate two loggers with diff levels of verbosity. Otherwise, I'm getting too much noise in console with messages from AJC.

Adding a default empty logger solves this problem. AJC gets silent, but it is still possible to pass a custom logger