### PR TITLE
test: add tests for custom task id

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -34,6 +34,8 @@ var (
 	ErrTaskTypeRequired = fmt.Errorf("task type is required")
 	// ErrTaskTypeInvalid indicates an invalid task type was given
 	ErrTaskTypeInvalid = fmt.Errorf("task type is invalid")
+	// ErrTaskIDInvalid indicates an invalid ID type was given
+	ErrTaskIDInvalid = fmt.Errorf("task ID is invalid")
 	// ErrTaskDependenciesFailed indicates that the task cannot be run as its dependencies failed
 	ErrTaskDependenciesFailed = fmt.Errorf("task dependencies failed")
 	// ErrTaskAlreadySigned indicates a task is already signed

--- a/task.go
+++ b/task.go
@@ -152,6 +152,10 @@ func NewTask(taskType string, payload any, opts ...TaskOpt) (*Task, error) {
 		}
 	}
 
+	if !IsValidName(t.ID) {
+		return nil, fmt.Errorf("%w: must match %s", ErrTaskIDInvalid, validNameMatcher)
+	}
+
 	if len(t.Dependencies) > 0 {
 		t.State = TaskStateBlocked
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -1,13 +1,33 @@
 package asyncjobs
 
 import (
+	"context"
+	"log"
 	"time"
 
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats.go"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Tasks", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
+		log.SetOutput(GinkgoWriter)
+	})
+
+	AfterEach(func() { cancel() })
+
+	testQueue := func() *Queue {
+		return &Queue{Name: "ginkgo"}
+	}
+
 	Describe("NewTask", func() {
 		It("Should create a valid task with options supplied", func() {
 			p, err := NewTask("parent", nil)
@@ -47,5 +67,70 @@ var _ = Describe("Tasks", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(msg).To(HaveLen(102))
 		})
+	})
+
+	Describe("NewTaskWithCustomID", func() {
+		It("Should create a valid task with valid custom ID", func() {
+			withJetStream(func(nc *nats.Conn, mgr *jsm.Manager) {
+				CustomIDGenerator := func(t *Task) error {
+					t.ID = "my-custom-id"
+					return nil
+				}
+
+				storage, err := newJetStreamStorage(nc, retryForTesting, &defaultLogger{})
+				Expect(err).ToNot(HaveOccurred())
+
+				q := testQueue()
+				err = storage.PrepareQueue(q, 1, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = storage.PrepareTasks(true, 1, time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+
+				task, err := NewTask("test", nil, CustomIDGenerator)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(task.ID).ToNot(HaveLen(0))
+				Expect(task.ID).To(Equal("my-custom-id"))
+
+				err = storage.EnqueueTask(ctx, q, task)
+				Expect(err).ToNot(HaveOccurred())
+
+				t, err := storage.LoadTaskByID(task.ID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(t.ID).To(Equal(task.ID))
+				Expect(task.ID).To(Equal("my-custom-id"))
+			})
+		})
+
+		It("Should not create a task with invalid custom ID", func() {
+			withJetStream(func(nc *nats.Conn, mgr *jsm.Manager) {
+				CustomIDGenerator := func(t *Task) error {
+					t.ID = "my.invalid.custom.id"
+					return nil
+				}
+
+				storage, err := newJetStreamStorage(nc, retryForTesting, &defaultLogger{})
+				Expect(err).ToNot(HaveOccurred())
+
+				q := testQueue()
+				err = storage.PrepareQueue(q, 1, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = storage.PrepareTasks(true, 1, time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+
+				task, err := NewTask("test", nil, CustomIDGenerator)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(task.ID).ToNot(HaveLen(0))
+				Expect(task.ID).To(Equal("my.invalid.custom.id"))
+
+				err = storage.EnqueueTask(ctx, q, task)
+				Expect(err).ToNot(HaveOccurred()) // TODO: test fails here because custom ID has invalid characters
+
+				t, err := storage.LoadTaskByID(task.ID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(t.ID).To(Equal(task.ID))
+				Expect(task.ID).To(Equal("my.invalid.custom.id"))
+			})
+		})
+
 	})
 })

--- a/task_test.go
+++ b/task_test.go
@@ -117,18 +117,8 @@ var _ = Describe("Tasks", func() {
 				err = storage.PrepareTasks(true, 1, time.Hour)
 				Expect(err).ToNot(HaveOccurred())
 
-				task, err := NewTask("test", nil, CustomIDGenerator)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(task.ID).ToNot(HaveLen(0))
-				Expect(task.ID).To(Equal("my.invalid.custom.id"))
-
-				err = storage.EnqueueTask(ctx, q, task)
-				Expect(err).ToNot(HaveOccurred()) // TODO: test fails here because custom ID has invalid characters
-
-				t, err := storage.LoadTaskByID(task.ID)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(t.ID).To(Equal(task.ID))
-				Expect(task.ID).To(Equal("my.invalid.custom.id"))
+				_, err = NewTask("test", nil, CustomIDGenerator)
+				Expect(err).To(MatchError(ErrTaskIDInvalid))
 			})
 		})
 


### PR DESCRIPTION
Tests for #131

The second test fail, if the provided ID has invalid characters, disallowed by NATS subject restrictions. Not sure, if you want to check the validity of ID, if it is provided by the library user. If that is the case, I can remove the 2nd test, and use `IsValidName` in the `CustomIDGenerator` in the first test to show the intent that it is the responsibility of the user to check for the validity of the ID.

