### PR TITLE
accept custom encoder for payload

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,8 @@ var (
 	ErrTaskDependenciesFailed = fmt.Errorf("task dependencies failed")
 	// ErrTaskAlreadySigned indicates a task is already signed
 	ErrTaskAlreadySigned = fmt.Errorf("task is already signed")
+	// ErrTaskPayloadEncoderAlreadySet indicates that the task already has an encoder for the payload
+	ErrTaskPayloadEncoderAlreadySet = fmt.Errorf("task payload encoder is already set")
 	// ErrTaskSignatureRequiresQueue indicates a signature request was made without configuring the queue name for a task
 	ErrTaskSignatureRequiresQueue = fmt.Errorf("signing a task requires the queue to be set")
 	// ErrTaskNotSigned indicates a task was loaded that had no signature while signatures are required


### PR DESCRIPTION
A Custom Task Payload Encoder can be provided using `TaskPayloadEncoder` `TaskOpt`. The default behaviour of `json.Marshal` is kept, if `TaskPayloadEncoder` is not provided. Only the first provided encoder is used to marshal, rest are discarded, because it does not make sense that the user would want to encode same payload multiple times with no effects. This behaviour is documented.

I did not proceed with a separate API mainly due to the need of duplicate logic of creating new task, which would result in extracting all the code of `NewTask` in a non-exported function, except the `json.Marshal(payload)` part.